### PR TITLE
Fix docs command bugs

### DIFF
--- a/src/main/kotlin/de/nycode/bankobot/commands/general/DocsCommand.kt
+++ b/src/main/kotlin/de/nycode/bankobot/commands/general/DocsCommand.kt
@@ -76,7 +76,8 @@ private val JavaDocArgument = WordArgument
         choice("JDK 11 Dokumentation", "jdk11")
         choice("JDK 8 Dokumentation", "jdk8")
         choice("Spigot 1.16.5 Dokumentation", "spigot1165")
-        choice("Paper Spigot dokumentation", "paper")
+        choice("Paper Spigot Dokumentation", "paper")
+        choice("JDA Dokumentation", "jda")
     }
 
 private object QueryArgument :
@@ -210,6 +211,20 @@ private fun renderClass(doc: DocumentedClassObject): EmbedBuilder = Embeds.doc(d
         }
     }
 
+    if (meta.subInterfaces.isNotEmpty()) {
+        field {
+            name = "All known sub interfaces"
+            value = meta.subInterfaces.formatReferences()
+        }
+    }
+
+    if (meta.subClasses.isNotEmpty()) {
+        field {
+            name = "All known subclasses"
+            value = meta.subClasses.formatReferences()
+        }
+    }
+
     if (doc.type == DocumentedObject.Type.ENUM) {
         field {
             name = "fields"
@@ -229,7 +244,7 @@ private fun formatMethodDefinition(doc: DocumentedMethodObject): String {
             " ",
             postfix = "\n"
         ) { "@${it.className}" }
-    }${doc.modifiers.joinToString(" ")} ${doc.metadata.returns} ${doc.name}(${
+    }${doc.modifiers.joinToString(" ") + if (doc.modifiers.isNotEmpty()) " " else ""}${doc.metadata.returns} ${doc.name}(${
         meta.parameters.joinToString {
             "${
                 it.annotations.joinToString(

--- a/src/main/kotlin/de/nycode/bankobot/commands/general/DocsCommand.kt
+++ b/src/main/kotlin/de/nycode/bankobot/commands/general/DocsCommand.kt
@@ -239,6 +239,7 @@ private fun formatMethodName(doc: DocumentedMethodObject) =
 
 private fun formatMethodDefinition(doc: DocumentedMethodObject): String {
     val meta = doc.metadata
+    @Suppress("MaxLineLength")
     return "${
         doc.annotations.joinToString(
             " ",

--- a/src/main/kotlin/de/nycode/bankobot/docdex/DocumentedReference.kt
+++ b/src/main/kotlin/de/nycode/bankobot/docdex/DocumentedReference.kt
@@ -37,7 +37,7 @@ import kotlinx.serialization.encoding.Encoder
 sealed class DocumentedReference(val raw: String, val `package`: String, val className: String) {
 
     companion object : KSerializer<DocumentedReference> {
-        private val packageRegex = "[a-z.]".toRegex()
+        private val packageRegex = "[a-z.0-9_]".toRegex()
 
         override val descriptor: SerialDescriptor =
             PrimitiveSerialDescriptor("reference", PrimitiveKind.STRING)


### PR DESCRIPTION
- Add JDA docs to slash command choices
- Fix package parsing (#46)
- Show sub interfaces and subclasses (#47)
- Fix typo in docs command choices
- Fix unwanted indent in method definitions (Method docs)
